### PR TITLE
Correct package names in require

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Example with asynchonous functions
 -------
 
 ``` js
-var CueSDK = require('node-cue-sdk');
+var CueSDK = require('cue-sdk-node');
 
 var cue = new CueSDK.CueSDK();
 
@@ -39,7 +39,7 @@ Example with synchonous functions
 -------
 
 ``` js
-var CueSDK = require('node-cue-sdk');
+var CueSDK = require('cue-sdk-node');
 
 var cue = new CueSDK.CueSDK();
 


### PR DESCRIPTION
Name says it all. You had `node-cue-sdk` previously but as the package is called `cue-sdk-node` on the npm registry that's the correct name to require.

If you do want it to be named `node-cue-sdk` you should adjust the name in `package.json`:

```diff
{
-  "name": "cue-sdk-node",
+  "name": "node-cue-sdk",
  "version": "1.2.1",
...
```

https://github.com/Yannicked/node-cue-sdk/blob/0c3ae550cb85242d30fb7a8e4a7db963455c7b97/package.json#L2